### PR TITLE
Changes days param to a double so sub 1 day ranges can be requested

### DIFF
--- a/src/commonMain/kotlin/drewcarlson/coingecko/CoinGeckoClient.kt
+++ b/src/commonMain/kotlin/drewcarlson/coingecko/CoinGeckoClient.kt
@@ -99,7 +99,7 @@ interface CoinGeckoClient {
     suspend fun getCoinMarketChartById(
         id: String,
         vsCurrency: String,
-        days: Int
+        days: Double
     ): MarketChart
 
     @Throws(CoinGeckoApiException::class, CancellationException::class)

--- a/src/commonMain/kotlin/drewcarlson/coingecko/CoinGeckoClientImpl.kt
+++ b/src/commonMain/kotlin/drewcarlson/coingecko/CoinGeckoClientImpl.kt
@@ -202,7 +202,7 @@ internal class CoinGeckoClientImpl(httpClient: HttpClient) : CoinGeckoClient {
     override suspend fun getCoinMarketChartById(
         id: String,
         vsCurrency: String,
-        days: Int
+        days: Double
     ): MarketChart =
         httpClient.get("coins/$id/market_chart") {
             parameter(VS_CURRENCY, vsCurrency)

--- a/src/commonTest/kotlin/CoinGeckoTests.kt
+++ b/src/commonTest/kotlin/CoinGeckoTests.kt
@@ -30,7 +30,7 @@ class CoinGeckoTests {
 
     @Test
     fun testMarketData() = runBlocking {
-        val btcData = coinGecko.getCoinMarketChartById("bitcoin", "usd", 3)
+        val btcData = coinGecko.getCoinMarketChartById("bitcoin", "usd", 3.0)
         assertTrue(btcData.prices.isNotEmpty())
         assertTrue(btcData.prices.first().isNotEmpty())
         assertTrue(btcData.marketCaps.isNotEmpty())


### PR DESCRIPTION
For some reason the market-chart/range API returns 0 results when specifying a range under 1 day (for example the last hour).

The market-chart API however, allows specifying days as a fraction. 0.5 days returns a market chart range for the last 12 hours.

This change allows fractional day params.